### PR TITLE
Fix Denial of Service Vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const URL = global.window ? window.URL : require('url').URL
-const urlRegex = require('url-regex')({ exact: true })
+const urlRegex = require('is-url-superb')
 
 const REGEX_HTTP_PROTOCOL = /^https?:\/\//i
 
 module.exports = url => {
   try {
     const { href } = new URL(url)
-    return REGEX_HTTP_PROTOCOL.test(href) && urlRegex.test(href)
+    return REGEX_HTTP_PROTOCOL.test(href) && urlRegex(href)
   } catch (err) {
     return false
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "whatwg"
   ],
   "dependencies": {
-    "url-regex": "~5.0.0"
+    "is-url-superb": "^4.0.0"
   },
   "devDependencies": {
     "ava": "latest",


### PR DESCRIPTION
## ✍️ Description

Affected versions of this package are vulnerable to Denial of Service. An attacker providing a very long url can cause a Denial of Service. The vulnerability exists in [#L11](https://github.com/Kikobeats/is-url-http/blob/d7df4f75db122da5a2950640632b0667f5e74651/index.js#L11)

# PoC
```node
const isUrlHttp = require('is-url-http')
isUrlHttp('https://kikobeats.test.3423423423sadasd.1312321321sadsadsad.21312312321asdasdsa.21312321asdasda.21312312312adasd23423.sadasdasd231412321.34234234asdasdasdasdassdasd.34234234asdasdas')
```

Fixes #7